### PR TITLE
add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,45 @@ For live sample output, try running `npm start` in this repo.
 
 ```
 
+### Verbose Mode
+
+For _extremely verbose_ formatted output, you can use the `-v` flag. This will print _all_ properties of the log object.
+
+A line like this...
+
+```js
+log.info({ justice: true }, 'Justice is served')
+```
+
+Whose raw output looks like this...
+
+```
+{"level":30,"time":1563400958346,"msg":"Justice is served","pid":3902,"hostname":"quant.hsd1.or.comcast.net","name":"test","justice":true,"v":1}
+```
+
+When fed to `pino-gris` like this...
+
+```sh
+output | pino-gris -v
+```
+
+Will be formatted like this:
+
+```
+14:59:23 ✨ test Justice is served
+
+  level: info
+  time: 1563400763379
+  msg: Justice is served
+  pid: 3737
+  hostname: quant.hsd1.or.comcast.net
+  name: test
+  justice: true
+  v: 1
+  message: Justice is served
+  ns:
+```
+
 ### Nota Bene
 
 Be careful how you use `pino`! It will do very different things depending on the order of arguments.

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var padLeft = require('pad-left')
 var indent = require('indent')
 var split = require('split2')
 var chalk = require('chalk')
-var nl = '\n'
 
+var nl = '\n'
 var emojiLog = {
   warn: '⚠️',
   info: '✨',
@@ -35,10 +35,11 @@ var pinoKeys = [
   'contentLength',
   'url'
 ]
+var verbose = process.argv.includes('-v')
 
 module.exports = PinoGris
 
-function PinoGris (opts) {
+function PinoGris () {
   return split(parse)
 }
 
@@ -162,7 +163,10 @@ function formatMessageName (message) {
 
 function formatExtra (obj) {
   const extra = Object.keys(obj)
-    .filter(key => !pinoKeys.includes(key))
+    .filter(key => {
+      if (verbose) return true
+      return !pinoKeys.includes(key)
+    })
     .reduce((acc, key) => {
       acc[key] = obj[key]
       return acc
@@ -177,7 +181,7 @@ function formatExtra (obj) {
     if (isObject(val)) val = JSON.stringify(val, null, 2)
 
     // limit very long string values
-    if (typeof val === 'string' && val.split('\n').length > lineLimit) {
+    if (!verbose && typeof val === 'string' && val.split('\n').length > lineLimit) {
       let arr = val.split('\n').slice(0, lineLimit)
       arr.push(`(truncated at ${lineLimit} lines)`)
       val = arr.join('\n')


### PR DESCRIPTION
### Verbose Mode

For _extremely verbose_ formatted output, you can use the `-v` flag. This will print _all_ properties of the log object.

A line like this...

```js
log.info({ justice: true }, 'Justice is served')
```

Whose raw output looks like this...

```
{"level":30,"time":1563400958346,"msg":"Justice is served","pid":3902,"hostname":"quant.hsd1.or.comcast.net","name":"test","justice":true,"v":1}
```

When fed to `pino-gris` like this...

```sh
output | pino-gris -v
```

Will be formatted like this:

```
14:59:23 ✨ test Justice is served

  level: info
  time: 1563400763379
  msg: Justice is served
  pid: 3737
  hostname: quant.hsd1.or.comcast.net
  name: test
  justice: true
  v: 1
  message: Justice is served
  ns:
```

