### PR TITLE
feat: add --line-limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ Will be formatted like this:
   msg: Justice is served
 ```
 
+### Line Limit
+
+Long string values are truncated at 100 lines by default. Use `--line-limit` to
+change the cap.
+
+```sh
+output | pino-gris --line-limit 500
+```
+
+The limit is ignored in verbose mode, which always prints everything.
+
 ### Nota Bene
 
 Be careful how you use `pino`! It will do very different things depending on the order of arguments.

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,27 @@
 #!/usr/bin/env node
+import { parseArgs } from 'node:util'
 import { pinoGris } from './index.js'
 
-const verbose = process.argv.includes('-v') || process.argv.includes('--verbose')
+const { values } = parseArgs({
+  strict: false,
+  allowPositionals: true,
+  options: {
+    verbose: { type: 'boolean', short: 'v', default: false },
+    'line-limit': { type: 'string' }
+  }
+})
 
-process.stdin.pipe(pinoGris({ verbose })).pipe(process.stdout)
+const verbose = Boolean(values.verbose)
+
+const raw = values['line-limit']
+let lineLimit: number | undefined
+if (raw !== undefined) {
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 0) {
+    process.stderr.write(`pino-gris: --line-limit must be a non-negative integer (got "${raw}")\n`)
+    process.exit(1)
+  }
+  lineLimit = n
+}
+
+process.stdin.pipe(pinoGris({ verbose, lineLimit })).pipe(process.stdout)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,12 @@ import { styleText } from 'node:util'
 export interface PinoGrisOptions {
   /** Show every field, skip the line-truncation limit on long string values. */
   verbose?: boolean
+  /** Cap long string values at this many lines (default 100); ignored when verbose. */
+  lineLimit?: number
 }
 
 const NL = '\n'
-const LINE_LIMIT = 100
+const DEFAULT_LINE_LIMIT = 100
 
 const emojiLog: Record<string, string> = {
   warn: '⚠️',
@@ -46,8 +48,7 @@ export function pinoGris(options: PinoGrisOptions = {}): Transform {
     transform(chunk, _encoding, callback) {
       buffer += chunk.toString()
       const lines = buffer.split(NL)
-      // split always yields at least one element, so pop is never undefined here;
-      // the last element is the trailing partial line, held until more data or flush
+      // split always yields >=1 element; the last is the partial line, held until flush
       buffer = lines.pop() as string
       for (const line of lines) this.push(parseLine(line, options))
       callback()
@@ -172,13 +173,17 @@ function formatExtra(obj: LogObject, options: PinoGrisOptions): string {
   const keys = Object.keys(obj).filter((key) => options.verbose || !pinoKeys.has(key))
   if (keys.length === 0) return ''
 
+  const limit = Number.isFinite(options.lineLimit)
+    ? (options.lineLimit as number)
+    : DEFAULT_LINE_LIMIT
+
   const lines = keys.map((key) => {
     const val = obj[key]
     let str = isPlainObject(val) ? JSON.stringify(val, null, 2) : String(val)
 
-    if (!options.verbose && str.split(NL).length > LINE_LIMIT) {
-      const head = str.split(NL).slice(0, LINE_LIMIT)
-      head.push(`(truncated at ${LINE_LIMIT} lines)`)
+    if (!options.verbose && str.split(NL).length > limit) {
+      const head = str.split(NL).slice(0, limit)
+      head.push(`(truncated at ${limit} lines)`)
       str = head.join(NL)
     }
     return styleText('gray', `${key}: ${str}`)

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -18,3 +18,15 @@ test('bin --verbose includes pino-internal keys', () => {
   const out = pipe(`${JSON.stringify({ level: 'info', msg: 'm', pid: 7 })}\n`, ['--verbose'])
   assert.match(out, /pid: 7/)
 })
+
+test('bin --line-limit overrides the default truncation point', () => {
+  const dump = Array.from({ length: 150 }, (_, i) => `line${i}`).join('\n')
+  const out = pipe(`${JSON.stringify({ level: 'info', msg: 'm', dump })}\n`, ['--line-limit', '10'])
+  assert.match(out, /truncated at 10 lines/)
+})
+
+test('bin --line-limit rejects a non-numeric value', () => {
+  const res = spawnSync('node', [bin, '--line-limit', 'abc'], { input: '', encoding: 'utf8' })
+  assert.equal(res.status, 1)
+  assert.match(res.stderr, /non-negative integer/)
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,6 +141,27 @@ test('truncates long string extras unless verbose', async () => {
   assert.doesNotMatch(out, /line149/)
 })
 
+test('lineLimit overrides the default truncation point', async () => {
+  const big = Array.from({ length: 150 }, (_, i) => `line${i}`).join('\n')
+  const out = await run(line({ level: 'info', msg: 'm', dump: big }), { lineLimit: 10 })
+  assert.match(out, /truncated at 10 lines/)
+  assert.match(out, /line9/)
+  assert.doesNotMatch(out, /line10/)
+})
+
+test('lineLimit raises the truncation point above the default', async () => {
+  const big = Array.from({ length: 150 }, (_, i) => `line${i}`).join('\n')
+  const out = await run(line({ level: 'info', msg: 'm', dump: big }), { lineLimit: 200 })
+  assert.match(out, /line149/)
+  assert.doesNotMatch(out, /truncated/)
+})
+
+test('a non-finite lineLimit falls back to the default', async () => {
+  const big = Array.from({ length: 150 }, (_, i) => `line${i}`).join('\n')
+  const out = await run(line({ level: 'info', msg: 'm', dump: big }), { lineLimit: Number.NaN })
+  assert.match(out, /truncated at 100 lines/)
+})
+
 test('verbose shows all keys and skips truncation', async () => {
   const big = Array.from({ length: 150 }, (_, i) => `line${i}`).join('\n')
   const out = await run(line({ level: 'info', msg: 'm', pid: 123, dump: big }), { verbose: true })


### PR DESCRIPTION
Closes #3.

Makes the long-string truncation cap configurable. Previously fixed at 100 lines (only `-v` could bypass it).

- `--line-limit <n>` CLI flag, and a `lineLimit` option on the library API
- defaults to 100; ignored in verbose mode
- non-integer/negative values to the flag exit 1 with a message

Note: verbose mode (`-v`) already prints everything and skips truncation, so `--line-limit` has no effect there.

## Verification

- `npm test`: 32 pass, 100% coverage, Biome clean
- `... | pino-gris --line-limit 500` raises the cap; `--line-limit abc` errors